### PR TITLE
chore(#630): reformatting transmute_vec_as_bytes to properly handle padding for usize and f32 types

### DIFF
--- a/fyrox-core/src/lib.rs
+++ b/fyrox-core/src/lib.rs
@@ -24,6 +24,7 @@ use fxhash::FxHashMap;
 use std::ffi::OsString;
 use std::hash::Hasher;
 use std::{
+    any::{Any, TypeId},
     borrow::Borrow,
     cmp,
     hash::Hash,
@@ -320,15 +321,38 @@ pub fn value_as_u8_slice<T: Sized>(v: &T) -> &'_ [u8] {
     unsafe { std::slice::from_raw_parts(v as *const T as *const u8, std::mem::size_of::<T>()) }
 }
 
+fn to_bytes_no_padding_usize(item: &Vec<usize>) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    for &byte in item {
+        bytes.extend_from_slice(&byte.to_ne_bytes());
+    }
+    bytes
+}
+
+fn to_bytes_no_padding_f32(item: &Vec<f32>) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    for &byte in item {
+        bytes.extend_from_slice(&byte.to_ne_bytes());
+    }
+    bytes
+}
+
 /// Takes a vector of trivially-copyable values and turns it into a vector of bytes.
-pub fn transmute_vec_as_bytes<T: Copy>(vec: Vec<T>) -> Vec<u8> {
-    unsafe {
-        let mut vec = std::mem::ManuallyDrop::new(vec);
-        Vec::from_raw_parts(
-            vec.as_mut_ptr() as *mut u8,
-            vec.len() * std::mem::size_of::<T>(),
-            vec.capacity() * std::mem::size_of::<T>(),
-        )
+pub fn transmute_vec_as_bytes<T: 'static>(vec: Vec<T>) -> Vec<u8> {
+    if TypeId::of::<T>() == TypeId::of::<usize>() {
+        let casted_vec: Vec<usize> = vec
+            .into_iter()
+            .map(|x| *(&x as &dyn Any).downcast_ref::<usize>().unwrap())
+            .collect();
+        return to_bytes_no_padding_usize(&casted_vec);
+    } else if TypeId::of::<T>() == TypeId::of::<f32>() {
+        let casted_vec: Vec<f32> = vec
+            .into_iter()
+            .map(|x| *(&x as &dyn Any).downcast_ref::<f32>().unwrap())
+            .collect();
+        return to_bytes_no_padding_f32(&casted_vec);
+    } else {
+        panic!("Unsupported type");
     }
 }
 
@@ -449,15 +473,15 @@ where
 mod test {
     use std::path::Path;
 
-    use fxhash::FxHashMap;
-    use uuid::uuid;
-
     use crate::{
         append_extension, cmp_strings_case_insensitive, combine_uuids, hash_combine,
-        make_relative_path,
+        make_relative_path, transmute_vec_as_bytes,
         visitor::{Visit, Visitor},
         BiDirHashMap,
     };
+    use fxhash::FxHashMap;
+    use std::mem::size_of;
+    use uuid::uuid;
 
     #[test]
     fn test_combine_uuids() {
@@ -626,5 +650,21 @@ mod test {
         assert!(cmp_strings_case_insensitive("FooBar", "FOOBaR"));
         assert!(!cmp_strings_case_insensitive("FooBaz", "FOOBaR"));
         assert!(cmp_strings_case_insensitive("foobar", "foobar"));
+    }
+
+    #[test]
+    fn test_transmute_vec_as_bytes_length_new_f32() {
+        let vec = vec![1.0f32, 2.0, 3.0];
+        let byte_vec = transmute_vec_as_bytes(vec.clone());
+        let expected_length = vec.len() * size_of::<f32>();
+        assert_eq!(byte_vec.len(), expected_length);
+    }
+
+    #[test]
+    fn test_transmute_vec_as_bytes_length_new_usize() {
+        let vec = vec![1usize, 2, 3];
+        let byte_vec = transmute_vec_as_bytes(vec.clone());
+        let expected_length = vec.len() * size_of::<usize>();
+        assert_eq!(byte_vec.len(), expected_length);
     }
 }


### PR DESCRIPTION
Can see implementation compared to the original in this [playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=00bf97e622f717df59cdbb2322daeabc)

Had a lot of problems dealing with a totally generic type. Noticed this function is currently referenced three times in the engine, two of the cases it was passing an f32 vec, and the third case it was a usize vec. If other types of vecs are required to be supported it can be implemented in a similar fashion and referenced in the transmute_vec_as_bytes fn. 
![image](https://github.com/FyroxEngine/Fyrox/assets/42050136/e65ee18c-8eca-42bb-878f-53d04401b336)

Added two tests for fyrox-core.src.lib::transmute_vec_as_bytes()

